### PR TITLE
fix: category/tag 슬러그 페이지 DYNAMIC_SERVER_USAGE 오류 수정 #45

### DIFF
--- a/src/app/categories/[slug]/page.tsx
+++ b/src/app/categories/[slug]/page.tsx
@@ -4,6 +4,8 @@ import { getCategoryBySlug } from "@/lib/strapi/client";
 import { buildPageMetadata, getSiteDefaults } from "@/lib/metadata";
 import { extractPageNumber, extractDecodedSlug } from "@/lib/searchParams";
 
+export const dynamic = "force-dynamic";
+
 type Props = {
   params: Promise<{ slug: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;

--- a/src/app/tags/[slug]/page.tsx
+++ b/src/app/tags/[slug]/page.tsx
@@ -4,6 +4,8 @@ import { getTagBySlug } from "@/lib/strapi/client";
 import { buildPageMetadata, getSiteDefaults } from "@/lib/metadata";
 import { extractPageNumber, extractDecodedSlug } from "@/lib/searchParams";
 
+export const dynamic = "force-dynamic";
+
 type Props = {
   params: Promise<{ slug: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;


### PR DESCRIPTION
## Summary

- `/categories/[slug]/` 및 `/tags/[slug]/` 접근 시 발생하는 HTTP 500 (`DYNAMIC_SERVER_USAGE`) 오류 수정
- 두 페이지에 `export const dynamic = "force-dynamic"` 추가로 명시적 동적 렌더링 강제

## Root Cause

Next.js 15/16 App Router에서 `generateStaticParams()`를 export하면 해당 route를 정적 최적화 대상으로 분류합니다. `generateStaticParams()` 가 빈 배열을 반환하더라도 이 export 자체가 static 컨텍스트 렌더링을 시도하게 만들고, `searchParams` (동적 API) 접근 시 `DYNAMIC_SERVER_USAGE` 예외가 발생합니다.

## Changes

| 파일 | 변경 |
|------|------|
| `src/app/categories/[slug]/page.tsx` | `export const dynamic = "force-dynamic"` 추가 |
| `src/app/tags/[slug]/page.tsx` | `export const dynamic = "force-dynamic"` 추가 |

## Test plan

- [ ] `/categories/{slug}/` 페이지 정상 응답 (HTTP 200) 확인
- [ ] `/tags/{slug}/` 페이지 정상 응답 (HTTP 200) 확인
- [ ] `npm run build` 정상 완료 확인

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)